### PR TITLE
add mouse events on viewport element to focus it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@altis/react-cornerstone-viewport",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Cornerstone medical image viewport component for React",
   "author": "Altis Labs",
   "license": "MIT",

--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -686,10 +686,22 @@ class CornerstoneViewport extends Component {
         <div
           className="viewport-element"
           onContextMenu={e => e.preventDefault()}
-          onMouseDown={e => e.preventDefault()}
+          onMouseDown={e => {
+            e.preventDefault();
+            this.element.focus();
+          }}
+          onMouseOver={e => {
+            e.preventDefault();
+            this.element.focus();
+          }}
+          onMouseOut={e => {
+            e.preventDefault();
+            this.element.blur();
+          }}
           ref={input => {
             this.element = input;
           }}
+          tabIndex={-1}
         >
           {displayLoadingIndicator && this.getLoadingIndicator()}
           {/* This classname is important in that it tells `cornerstone` to not


### PR DESCRIPTION
This PR focuses the viewport on mouse operations (hover and click) so that keyboard input can be detected when the element is in focus.