### PR TITLE
Enable viewer overlay metadata overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@altis-labs/react-cornerstone-viewport",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Cornerstone medical image viewport component for React",
   "author": "Altis Labs",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-resize-detector": "^4.2.1"
   },
   "devDependencies": {
-    "@altis-labs/cornerstone-tools": "^1.0.0",
+    "@altis-labs/cornerstone-tools": "^1.1.19",
     "@babel/core": "^7.2.0",
     "@babel/plugin-proposal-class-properties": "^7.2.1",
     "@babel/plugin-transform-runtime": "^7.4.3",

--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -77,7 +77,12 @@ class CornerstoneViewport extends Component {
     isOverlayVisible: PropTypes.bool,
     //custom
     imageIdIndexChange: PropTypes.func,
-    seriesDateLabel: PropTypes.string,
+    labelOverrides: PropTypes.shape({
+      seriesDate: PropTypes.string,
+      patientName: PropTypes.string,
+      patientId: PropTypes.string,
+      studyDescription: PropTypes.string,
+    })
   };
 
   static defaultProps = {
@@ -342,7 +347,7 @@ class CornerstoneViewport extends Component {
     const {
       viewportOverlayComponent: Component,
       imageIds,
-      seriesDateLabel,
+      labelOverrides,
     } = this.props;
     const {
       imageIdIndex,
@@ -363,7 +368,7 @@ class CornerstoneViewport extends Component {
           windowWidth={windowWidth}
           windowCenter={windowCenter}
           imageId={imageId}
-          seriesDateLabel={seriesDateLabel}
+          labelOverrides={labelOverrides}
         />
       )
     );

--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -100,7 +100,7 @@ class CornerstoneViewport extends Component {
     resizeThrottleMs: 200,
     tools: [],
     imageIdIndexChange: null,
-    seriesDateLabel: null,
+    labelOverrides: null,
   };
 
   constructor(props) {

--- a/src/CornerstoneViewport/CornerstoneViewport.js
+++ b/src/CornerstoneViewport/CornerstoneViewport.js
@@ -82,6 +82,7 @@ class CornerstoneViewport extends Component {
       patientName: PropTypes.string,
       patientId: PropTypes.string,
       studyDescription: PropTypes.string,
+      seriesDescription: PropTypes.string,
     })
   };
 

--- a/src/ViewportOverlay/ViewportOverlay.js
+++ b/src/ViewportOverlay/ViewportOverlay.js
@@ -58,13 +58,7 @@ class ViewportOverlay extends PureComponent {
       scale,
       windowWidth,
       windowCenter,
-      labelOverrides: {
-        seriesDate: seriesDateOverride,
-        patientName: patientNameOverride,
-        patientId: patientIdOverride,
-        studyDescription: studyDescriptionOverride
-      }
-
+      labelOverrides
     } = this.props;
 
     if (!imageId) {
@@ -100,6 +94,13 @@ class ViewportOverlay extends PureComponent {
     const imageDimensions = `${columns} x ${rows}`;
 
     const { imageIndex, stackSize } = this.props;
+
+    const {
+      seriesDate: seriesDateOverride,
+          patientName: patientNameOverride,
+        patientId: patientIdOverride,
+        studyDescription: studyDescriptionOverride
+    } = labelOverrides ?? {};
 
     const patientNameLabel = patientNameOverride ?? formatPN(patientName);
     const patientIdLabel = patientIdOverride ?? patientId;

--- a/src/ViewportOverlay/ViewportOverlay.js
+++ b/src/ViewportOverlay/ViewportOverlay.js
@@ -35,6 +35,7 @@ function getCompression(imageId) {
   return 'Lossless / Uncompressed';
 }
 
+
 class ViewportOverlay extends PureComponent {
   static propTypes = {
     scale: PropTypes.number.isRequired,
@@ -43,7 +44,12 @@ class ViewportOverlay extends PureComponent {
     imageId: PropTypes.string.isRequired,
     imageIndex: PropTypes.number.isRequired,
     stackSize: PropTypes.number.isRequired,
-    seriesDateLabel: PropTypes.string,
+    labelOverrides: PropTypes.shape({
+      seriesDate: PropTypes.string,
+      patientName: PropTypes.string,
+      patientId: PropTypes.string,
+      studyDescription: PropTypes.string,
+    })
   };
 
   render() {
@@ -52,7 +58,13 @@ class ViewportOverlay extends PureComponent {
       scale,
       windowWidth,
       windowCenter,
-      seriesDateLabel,
+      labelOverrides: {
+        seriesDate: seriesDateOverride,
+        patientName: patientNameOverride,
+        patientId: patientIdOverride,
+        studyDescription: studyDescriptionOverride
+      }
+
     } = this.props;
 
     if (!imageId) {
@@ -89,19 +101,21 @@ class ViewportOverlay extends PureComponent {
 
     const { imageIndex, stackSize } = this.props;
 
-    let seriesLabel = seriesDateLabel
-      ? seriesDateLabel
-      : `${formatDA(studyDate)} ${formatTM(studyTime)}`;
+    const patientNameLabel = patientNameOverride ?? formatPN(patientName);
+    const patientIdLabel = patientIdOverride ?? patientId;
+
+    const studyDescriptionLabel = studyDescriptionOverride ?? studyDescription;
+    const seriesDateLabel = seriesDateOverride ?? `${formatDA(studyDate)} ${formatTM(studyTime)}`;
 
     const normal = (
       <React.Fragment>
         <div className="top-left overlay-element">
-          <div>{formatPN(patientName)}</div>
-          <div>{patientId}</div>
+          <div>{patientNameLabel}</div>
+          <div>{patientIdLabel}</div>
         </div>
         <div className="top-right overlay-element">
-          <div>{studyDescription}</div>
-          <div>{seriesLabel}</div>
+          <div>{studyDescriptionLabel}</div>
+          <div>{seriesDateLabel}</div>
         </div>
         <div className="bottom-right overlay-element">
           <div>Zoom: {zoomPercentage}%</div>

--- a/src/ViewportOverlay/ViewportOverlay.js
+++ b/src/ViewportOverlay/ViewportOverlay.js
@@ -49,6 +49,7 @@ class ViewportOverlay extends PureComponent {
       patientName: PropTypes.string,
       patientId: PropTypes.string,
       studyDescription: PropTypes.string,
+      seriesDescription: PropTypes.string,
     })
   };
 
@@ -97,9 +98,10 @@ class ViewportOverlay extends PureComponent {
 
     const {
       seriesDate: seriesDateOverride,
-          patientName: patientNameOverride,
-        patientId: patientIdOverride,
-        studyDescription: studyDescriptionOverride
+      patientName: patientNameOverride,
+      patientId: patientIdOverride,
+      studyDescription: studyDescriptionOverride,
+      seriesDescription: seriesDescriptionOverride,
     } = labelOverrides ?? {};
 
     const patientNameLabel = patientNameOverride ?? formatPN(patientName);
@@ -107,6 +109,8 @@ class ViewportOverlay extends PureComponent {
 
     const studyDescriptionLabel = studyDescriptionOverride ?? studyDescription;
     const seriesDateLabel = seriesDateOverride ?? `${formatDA(studyDate)} ${formatTM(studyTime)}`;
+
+    const seriesDescriptionLabel = seriesDescriptionOverride ?? seriesDescription;
 
     const normal = (
       <React.Fragment>
@@ -141,7 +145,7 @@ class ViewportOverlay extends PureComponent {
                 ? `Thick: ${formatNumberPrecision(sliceThickness, 2)} mm`
                 : ''}
             </div>
-            <div>{seriesDescription}</div>
+            <div>{seriesDescriptionLabel}</div>
           </div>
         </div>
       </React.Fragment>


### PR DESCRIPTION
Closes #8 

Allows overriding of patient metadata in viewer overlay